### PR TITLE
Override getListenedPropertyMask via MVEL3 read-properties (#19)

### DIFF
--- a/drlx-parser-core/src/main/java/org/drools/drlx/builder/DrlxLambdaConstraint.java
+++ b/drlx-parser-core/src/main/java/org/drools/drlx/builder/DrlxLambdaConstraint.java
@@ -3,17 +3,25 @@ package org.drools.drlx.builder;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.List;
+import java.util.Optional;
 
+import org.drools.base.base.ObjectType;
 import org.drools.base.base.ValueResolver;
 import org.drools.base.reteoo.BaseTuple;
+import org.drools.base.reteoo.PropertySpecificUtil;
 import org.drools.base.rule.ContextEntry;
 import org.drools.base.rule.Declaration;
 import org.drools.base.rule.MutableTypeConstraint;
+import org.drools.base.rule.Pattern;
+import org.drools.util.bitmask.BitMask;
 import org.kie.api.runtime.rule.FactHandle;
 import org.mvel3.ClassManager;
 import org.mvel3.CompilerParameters;
 import org.mvel3.Evaluator;
 import org.mvel3.MVEL;
+
+import static org.drools.base.reteoo.PropertySpecificUtil.getEmptyPropertyReactiveMask;
 
 public class DrlxLambdaConstraint extends MutableTypeConstraint<ContextEntry[]> implements EvaluatorSink {
 
@@ -80,6 +88,24 @@ public class DrlxLambdaConstraint extends MutableTypeConstraint<ContextEntry[]> 
     @Override
     public void replaceDeclaration(Declaration declaration, Declaration declaration1) {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public BitMask getListenedPropertyMask(Optional<Pattern> pattern,
+                                           ObjectType objectType,
+                                           List<String> settableProperties) {
+        String[] reads = evaluator.getReadProperties();
+        if (reads.length == 0) {
+            return super.getListenedPropertyMask(pattern, objectType, settableProperties);
+        }
+        BitMask mask = getEmptyPropertyReactiveMask(settableProperties.size());
+        for (String prop : reads) {
+            int pos = settableProperties.indexOf(prop);
+            if (pos >= 0) { // ignore properties that aren't settable on the pattern type
+                mask = mask.set(pos + PropertySpecificUtil.CUSTOM_BITS_OFFSET);
+            }
+        }
+        return mask;
     }
 
     @Override

--- a/drlx-parser-core/src/test/java/org/drools/drlx/builder/syntax/PropertyReactiveWatchListTest.java
+++ b/drlx-parser-core/src/test/java/org/drools/drlx/builder/syntax/PropertyReactiveWatchListTest.java
@@ -193,6 +193,38 @@ class PropertyReactiveWatchListTest extends DrlxBuilderTestSupport {
     }
 
     @Test
+    void conditionPlusWatchList_doesNotFireOnUnrelated() {
+        final String rule = """
+                package org.drools.drlx.parser;
+
+                import org.drools.drlx.domain.ReactiveEmployee;
+                import org.drools.drlx.ruleunit.MyUnit;
+
+                unit MyUnit;
+
+                rule R1 {
+                    var e : /reactiveEmployees[salary > 0][basePay],
+                    do { }
+                }
+                """;
+
+        withSession(rule, (kieSession, listener) -> {
+            EntryPoint ep = kieSession.getEntryPoint("reactiveEmployees");
+            ReactiveEmployee emp = new ReactiveEmployee(6000, 4000, 1000);
+            FactHandle fh = ep.insert(emp);
+
+            assertThat(kieSession.fireAllRules()).isEqualTo(1);
+            listener.getAfterMatchFired().clear();
+
+            // bonusPay neither in watch list nor read by constraint → must NOT re-fire.
+            emp.setBonusPay(2000);
+            ep.update(fh, emp, "bonusPay");
+            assertThat(kieSession.fireAllRules()).isEqualTo(0);
+            assertThat(listener.getAfterMatchFired()).isEmpty();
+        });
+    }
+
+    @Test
     void duplicateWildcard_throwsAtBuild() {
         final String rule = """
                 package org.drools.drlx.parser;

--- a/drlx-parser-core/src/test/java/org/drools/drlx/builder/syntax/PropertyReactiveWatchListTest.java
+++ b/drlx-parser-core/src/test/java/org/drools/drlx/builder/syntax/PropertyReactiveWatchListTest.java
@@ -8,11 +8,6 @@ import org.kie.api.runtime.rule.FactHandle;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-// MVP scope: watch list fully restricts modification re-evaluation only when
-// the pattern has no alpha constraints. With conditions present, modifications
-// still propagate through the alpha because DrlxLambdaConstraint does not yet
-// override getListenedPropertyMask. See follow-up issue on DrlxLambdaConstraint
-// property-mask reporting.
 class PropertyReactiveWatchListTest extends DrlxBuilderTestSupport {
 
     @Test

--- a/drlx-parser-core/src/test/java/org/drools/drlx/builder/syntax/PropertyReactiveWatchListTest.java
+++ b/drlx-parser-core/src/test/java/org/drools/drlx/builder/syntax/PropertyReactiveWatchListTest.java
@@ -193,6 +193,70 @@ class PropertyReactiveWatchListTest extends DrlxBuilderTestSupport {
     }
 
     @Test
+    void conditionPlusWatchList_firesOnConstraintProp() {
+        final String rule = """
+                package org.drools.drlx.parser;
+
+                import org.drools.drlx.domain.ReactiveEmployee;
+                import org.drools.drlx.ruleunit.MyUnit;
+
+                unit MyUnit;
+
+                rule R1 {
+                    var e : /reactiveEmployees[salary > 0][basePay],
+                    do { }
+                }
+                """;
+
+        withSession(rule, (kieSession, listener) -> {
+            EntryPoint ep = kieSession.getEntryPoint("reactiveEmployees");
+            ReactiveEmployee emp = new ReactiveEmployee(6000, 4000, 1000);
+            FactHandle fh = ep.insert(emp);
+
+            assertThat(kieSession.fireAllRules()).isEqualTo(1);
+            listener.getAfterMatchFired().clear();
+
+            // salary read by constraint → re-fire required.
+            emp.setSalary(7000);
+            ep.update(fh, emp, "salary");
+            assertThat(kieSession.fireAllRules()).isEqualTo(1);
+            assertThat(listener.getAfterMatchFired()).containsExactly("R1");
+        });
+    }
+
+    @Test
+    void conditionPlusWatchList_firesOnWatchProp() {
+        final String rule = """
+                package org.drools.drlx.parser;
+
+                import org.drools.drlx.domain.ReactiveEmployee;
+                import org.drools.drlx.ruleunit.MyUnit;
+
+                unit MyUnit;
+
+                rule R1 {
+                    var e : /reactiveEmployees[salary > 0][basePay],
+                    do { }
+                }
+                """;
+
+        withSession(rule, (kieSession, listener) -> {
+            EntryPoint ep = kieSession.getEntryPoint("reactiveEmployees");
+            ReactiveEmployee emp = new ReactiveEmployee(6000, 4000, 1000);
+            FactHandle fh = ep.insert(emp);
+
+            assertThat(kieSession.fireAllRules()).isEqualTo(1);
+            listener.getAfterMatchFired().clear();
+
+            // basePay in watch list → re-fire required.
+            emp.setBasePay(5000);
+            ep.update(fh, emp, "basePay");
+            assertThat(kieSession.fireAllRules()).isEqualTo(1);
+            assertThat(listener.getAfterMatchFired()).containsExactly("R1");
+        });
+    }
+
+    @Test
     void conditionPlusWatchList_doesNotFireOnUnrelated() {
         final String rule = """
                 package org.drools.drlx.parser;


### PR DESCRIPTION
## Summary

- Override `DrlxLambdaConstraint.getListenedPropertyMask` to derive a property-specific BitMask from the new `Evaluator.getReadProperties()` API (introduced in [mvel/mvel#423](https://github.com/mvel/mvel/issues/423), already merged upstream). Mirrors `drools-modelcompiler.LambdaConstraint:170-188`.
- Closes the gap from #13: `[salary > 0][basePay]` now correctly suppresses re-fire on modifications to constraint-unrelated, non-watched properties. Previously the constraint mask defaulted to `AllSetButLastBitMask`, which defeated the watch list whenever an alpha condition was present.
- Adds three behavioural tests covering the condition + watch-list combinations, removes the obsolete `// MVP scope:` limitation comment.

Closes #19

## Test plan

- [x] `PropertyReactiveWatchListTest.conditionPlusWatchList_doesNotFireOnUnrelated` — modify a property neither read by the constraint nor in the watch list → no re-fire (regression case for #19).
- [x] `PropertyReactiveWatchListTest.conditionPlusWatchList_firesOnConstraintProp` — modify a property read by the constraint → re-fires.
- [x] `PropertyReactiveWatchListTest.conditionPlusWatchList_firesOnWatchProp` — modify a watched property → re-fires.
- [x] Full DRLX suite green: 111 passing (was 108, +3), 0 failures.
- [x] Existing 7 tests in `PropertyReactiveWatchListTest` continue to pass.

## Notes

Implementation deviations from the original spec are recorded in `specs/2026-04-27-constraint-mask-design.md` and `plans/2026-04-27-constraint-mask-implementation.md` (workspace repo). Highlights:
- `VariableAnalyser` collects every `NameExpr`/`DrlNameExpr`; consumer-side filtering via `settableProperties` handles cross-pattern bindings and other non-property identifiers.
- `MethodCallExpr` getter decoding (`getBasePay()` → `basePay`) is not supported because MVEL3's symbol resolver rejects bare getter calls in user expressions.
- `getReadProperties()` codegen runs after the eval method to keep `MVELCompiler.registerAndRename`'s `findFirst(MethodDeclaration.class)` correct.

## Out of scope

- Nested property access (`address.city` → only `address`).
- Method calls with arguments.
- Aliased context references (`this.salary`, `e.salary`).
- Explicit `@Watch`-style overrides / `getReactivityBitMask()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)